### PR TITLE
Fix Minor Typo in Chapter 2 & 3

### DIFF
--- a/src/chap_2_functional.res
+++ b/src/chap_2_functional.res
@@ -188,7 +188,7 @@ SimpleTest.assertEqual(
   ~msg="[exercise 2] Calculate discount for 499",
 )
 SimpleTest.assertEqual(
-  ~expected=50,
+  ~expected=40,
   ~actual=calculateDiscount(500),
   ~msg="[exercise 2] Calculate discount for 500",
 )
@@ -221,7 +221,7 @@ SimpleTest.assertEqual(
   available with you. So you can write this:
   
     ```
-    let hindleyPartial = fullName("J. Roger")
+    let hindleyPartial = fullname("J. Roger")
     ```
   
   The `hindleyPartial` is a **partial application** of the function
@@ -231,7 +231,7 @@ SimpleTest.assertEqual(
   Look at the type signatures of both functions:
 
     ```
-    let fullName: (string, string) => string
+    let fullname: (string, string) => string
 
     let hindleyPartial: string => string
     ```

--- a/src/chap_3_adt.res
+++ b/src/chap_3_adt.res
@@ -363,7 +363,7 @@ SimpleTest.assertEqual(
   ~msg="[exercise 5] text input for entering first name",
 )
 SimpleTest.assertEqual(
-  ~expected=`<input type="number" name="tickets" min=0 max=5/>`,
+  ~expected=`<input type="number" name="tickets" min="0" max="5" />`,
   ~actual=formInputToHTML(Number("tickets", 0, 5)),
   ~msg="[exercise 5] input for buying upto 5 tickets",
 )
@@ -587,7 +587,7 @@ let projectLinkHTML2 = project => {
   Since records are immutable, this is how you update the value of a 
   record field.
 
-  The `...atom` at the beginning of the record destructures the existing
+  The `...atom` at the beginning of the record spreads (unpacks) the existing
   field values in the record `atom`. The `people` field is then increased
   by one.
  */
@@ -653,7 +653,7 @@ let codersAtWork = {
 
     <div>
       <h2>Coders at Work: Reflections on the Craft of Programming</h2>
-      <p>10 new Paperback avialable in stock</p>
+      <p>10 new Paperback available in stock</p>
     </div>
 
   Notes:
@@ -671,7 +671,7 @@ let bookToHTML = book => ""
 
 let expectedBookHTML = `<div>
     <h2>Coders at Work: Reflections on the Craft of Programming</h2>
-    <p>10 new Paperback avialable in stock</p>
+    <p>10 new Paperback available in stock</p>
 </div>`
 SimpleTest.assertEqual(
   ~expected=expectedBookHTML,


### PR DESCRIPTION
### Chapter 2 

- On `SimpleTest` - Ex. 2, since `(500 - 200) * 0.05 + 25` makes `40`, test case should be updated.

- Fixed typo in function signature.
 `fullName`  ->  `fullname`, on other areas it is referenced as `fullname`.
 
 ### Chapter 3
 
- On `SimpleTest` - Ex. 3, **though just an example**, to make it uniform, attribute values are enclosed in quotes.
  👉 [**Good Info here**](http://jkorpela.fi/qattr.html) - If we pass a value with `/>`, then after string interpolation, it would end the tag.
- I thought in the same context, where `...` is spread operator, which will be used to unpack (in JS).
- Fixed minor typos.
